### PR TITLE
Fix import cycle

### DIFF
--- a/customerrors/error.go
+++ b/customerrors/error.go
@@ -36,10 +36,11 @@ func (sw SwError) Exit() {
 
 func Check(err error, message string) {
 	if err != nil {
+		location, _ := GetLogFileLocation()
 		myErr := SwError{Message: message, Err: err}
 		LogLady.WithField("error", err).Error(message)
 		fmt.Println(myErr.Error())
-		fmt.Printf("For more information, check the log file at %s\n", GetLogFileLocation())
+		fmt.Printf("For more information, check the log file at %s\n", location)
 		fmt.Println("nancy version:", buildversion.BuildVersion)
 		myErr.Exit()
 	}

--- a/customerrors/error.go
+++ b/customerrors/error.go
@@ -36,7 +36,7 @@ func (sw SwError) Exit() {
 
 func Check(err error, message string) {
 	if err != nil {
-		location, _ := GetLogFileLocation()
+		location, _ := LogFileLocation()
 		myErr := SwError{Message: message, Err: err}
 		LogLady.WithField("error", err).Error(message)
 		fmt.Println(myErr.Error())

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -46,7 +46,7 @@ func doInit(args []string) {
 	LogLady.Level = logrus.InfoLevel
 	LogLady.Formatter = &logrus.JSONFormatter{}
 
-	location, err := GetLogFileLocation()
+	location, err := LogFileLocation()
 
 	file, err := os.OpenFile(location, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0666)
 	if err != nil {
@@ -80,8 +80,8 @@ func useTestLogFile(args []string) bool {
 	return false
 }
 
-// GetLogFileLocation will return the location on disk of the log file
-func GetLogFileLocation() (result string, err error) {
+// LogFileLocation will return the location on disk of the log file
+func LogFileLocation() (result string, err error) {
 	result, _ = os.UserHomeDir()
 	err = os.MkdirAll(path.Join(result, types.OssIndexDirName), os.ModePerm)
 	if err != nil {

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -35,10 +35,13 @@ var DefaultLogFile = DefaultLogFilename
 var LogLady = logrus.New()
 
 func init() {
-	doInit(os.Args)
+	err := doInit(os.Args)
+	if err != nil {
+		panic(err)
+	}
 }
 
-func doInit(args []string) {
+func doInit(args []string) (err error) {
 	if useTestLogFile(args) {
 		DefaultLogFile = TestLogfilename
 	}
@@ -50,9 +53,11 @@ func doInit(args []string) {
 
 	file, err := os.OpenFile(location, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0666)
 	if err != nil {
-		LogLady.WithField("err", err).Error("Unable to open log file")
+		return
 	}
 	LogLady.Out = file
+
+	return
 }
 
 func stringPrefixInSlice(a string, list []string) bool {

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -50,6 +50,9 @@ func doInit(args []string) (err error) {
 	LogLady.Formatter = &logrus.JSONFormatter{}
 
 	location, err := LogFileLocation()
+	if err != nil {
+		return
+	}
 
 	file, err := os.OpenFile(location, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0666)
 	if err != nil {

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -74,7 +74,10 @@ func TestInit(t *testing.T) {
 	teardownTestCase := setupTestCase(t)
 	defer teardownTestCase(t)
 
-	doInit([]string{"yadda", "-test.v"})
+	err := doInit([]string{"yadda", "-test.v"})
+	if err != nil {
+		t.Error(err)
+	}
 	assert.Equal(t, TestLogfilename, DefaultLogFile)
 }
 
@@ -82,7 +85,10 @@ func TestInitIQ(t *testing.T) {
 	teardownTestCase := setupTestCase(t)
 	defer teardownTestCase(t)
 
-	doInit([]string{"yadda", "-iq", "-test.v"})
+	err := doInit([]string{"yadda", "-iq", "-test.v"})
+	if err != nil {
+		t.Error(err)
+	}
 	assert.Equal(t, DefaultLogFilename, DefaultLogFile)
 }
 
@@ -90,6 +96,9 @@ func TestInitDefault(t *testing.T) {
 	teardownTestCase := setupTestCase(t)
 	defer teardownTestCase(t)
 
-	doInit([]string{"yadda", "-yadda"})
+	err := doInit([]string{"yadda", "-yadda"})
+	if err != nil {
+		t.Error(err)
+	}
 	assert.Equal(t, DefaultLogFilename, DefaultLogFile)
 }

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestLogger(t *testing.T) {
-	location, _ := GetLogFileLocation()
+	location, _ := LogFileLocation()
 	if !strings.Contains(location, TestLogfilename) {
 		t.Errorf("Nancy test file not in log file location. args: %+v", os.Args)
 	}

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -26,13 +26,14 @@ import (
 )
 
 func TestLogger(t *testing.T) {
-	if !strings.Contains(GetLogFileLocation(), TestLogfilename) {
+	location, _ := GetLogFileLocation()
+	if !strings.Contains(location, TestLogfilename) {
 		t.Errorf("Nancy test file not in log file location. args: %+v", os.Args)
 	}
 
 	LogLady.Info("Test")
 
-	dat, err := ioutil.ReadFile(GetLogFileLocation())
+	dat, err := ioutil.ReadFile(location)
 	if err != nil {
 		t.Error("Unable to open log file")
 	}

--- a/logger/old_logger.go
+++ b/logger/old_logger.go
@@ -1,0 +1,21 @@
+package logger
+
+import (
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/sonatype-nexus-community/nancy/types"
+)
+
+// GetLogFileLocation will return the location on disk of the log file
+func GetLogFileLocation() (result string) {
+	result, _ = os.UserHomeDir()
+	err := os.MkdirAll(path.Join(result, types.OssIndexDirName), os.ModePerm)
+	if err != nil {
+		fmt.Println(err)
+		return ""
+	}
+	result = path.Join(result, types.OssIndexDirName, DefaultLogFile)
+	return
+}


### PR DESCRIPTION
This fixes the import cycle issue we saw in the original PR. It removes a dependency on `customerrors` in `logger` and switches to 

This pull request makes the following changes:
* Adds a new function in `logger.go` that returns err, likely an oversight from the first time 
* Adds a case to panic in logger, as we likely should panic anyways
* Updates tests

cc @bhamail / @DarthHater
